### PR TITLE
Update dev environment and test all supported Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ comet_core.code-workspace
 .cache/
 .vscode/
 test-reports/
+
+# Pyenv
+.python-version

--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,14 @@ enable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=no-name-in-module,relative-import,suppressed-message,locally-disabled,locally-enabled,too-few-public-methods
+disable=no-name-in-module,
+        relative-import,
+        suppressed-message,
+        locally-disabled,
+        locally-enabled,
+        too-few-public-methods,
+        inconsistent-return-statements,
+        bad-continuation
 
 [REPORTS]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ install:
 # select tox envs to run
 matrix:
   include:
-  - python: '3.6'
-    env: TOXENV=py36
-  - python: '3.6'
-    env: TOXENV=lint
+  - python: 3.6
+    env: TOXENV=py36,black,lint
+  - python: 3.7
+    env: TOXENV=py37
+  - python: 3.8
+    env: TOXENV=py38
 
 # run tox
 script:

--- a/comet_common/comet_input_google_pubsub.py
+++ b/comet_common/comet_input_google_pubsub.py
@@ -46,29 +46,26 @@ class PubSubInput(CometInput):
             Exception: if smth happens (sorry)
         """
         try:
-            source_type = message.attributes.get('source_type', None)
-            LOG.debug('Received pubsub message.', extra={'source_type': source_type,
-                                                         'msg_received': message})
+            source_type = message.attributes.get("source_type", None)
+            LOG.debug("Received pubsub message.", extra={"source_type": source_type, "msg_received": message})
             data = message.data.decode()
             if self.message_callback(source_type, data):
-                LOG.debug('Acknowledge pubsub message.', extra={'source_type': source_type,
-                                                                'msg_acked': message})
+                LOG.debug("Acknowledge pubsub message.", extra={"source_type": source_type, "msg_acked": message})
                 message.ack()
                 return
         except CometAlertException as e:
             if e.drop:
-                LOG.warning('Dropping invalid pubsub message', extra={'source_type': source_type,
-                                                                      'msg_dropped': message})
+                LOG.warning(
+                    "Dropping invalid pubsub message", extra={"source_type": source_type, "msg_dropped": message}
+                )
                 message.ack()
                 return
         except Exception as _:
-            LOG.error('Message processing error')
-            LOG.warning('Refused (nacked) pubsub message.', extra={'source_type': source_type,
-                                                                   'msg_nacked': message})
+            LOG.error("Message processing error")
+            LOG.warning("Refused (nacked) pubsub message.", extra={"source_type": source_type, "msg_nacked": message})
             message.nack()
             raise
-        LOG.warning('Refused (nacked) pubsub message.', extra={'source_type': source_type,
-                                                               'msg_nacked': message})
+        LOG.warning("Refused (nacked) pubsub message.", extra={"source_type": source_type, "msg_nacked": message})
         message.nack()
 
     def stop(self):

--- a/comet_common/comet_parser_detectify.py
+++ b/comet_common/comet_parser_detectify.py
@@ -31,6 +31,7 @@ class DetectifyPayloadSchema(Schema):
     Args:
         Schema (marshmallow.Schema): schema
     """
+
     signature = fields.Str(required=True)
     url = fields.Str(required=True)
     title = fields.Str(required=True)
@@ -41,6 +42,7 @@ class DetectifyPayloadSchema(Schema):
 
 class DetectifySchema(Schema):
     """Schema for Detectify"""
+
     scan_token = fields.Str(required=True)
     profile_token = fields.Str(required=True)
     domain = fields.Str(required=True)

--- a/comet_common/comet_parser_forseti.py
+++ b/comet_common/comet_parser_forseti.py
@@ -16,24 +16,20 @@
 
 from marshmallow import fields, Schema, validate, validates_schema, ValidationError
 
-SUPPORTED_RESOURCE_TYPES = [
-    'bucket',
-    'project',
-    'cloudsql',
-    'bigquery_dataset'
-]
+SUPPORTED_RESOURCE_TYPES = ["bucket", "project", "cloudsql", "bigquery_dataset"]
 
 # Supported resource and their required fields
 SUPPORTED_RESOURCE = {
-    'policy_violations': ['member', 'role'],
-    'buckets_acl_violations': ['bucket', 'entity', 'role'],
-    'cloudsql_acl_violations': ['instance_name'],
-    'bigquery_acl_violations': ['dataset_id']
+    "policy_violations": ["member", "role"],
+    "buckets_acl_violations": ["bucket", "entity", "role"],
+    "cloudsql_acl_violations": ["instance_name"],
+    "bigquery_acl_violations": ["dataset_id"],
 }
 
 
 class ForsetiSchema(Schema):
     """Schema for Forseti"""
+
     id = fields.Int(required=True)
     project_id = fields.Str(required=True)
     project_owner = fields.Str(required=True, allow_none=True)
@@ -52,15 +48,16 @@ class ForsetiSchema(Schema):
                              or resource_type or resource are not provided
         """
 
-        if 'resource' not in data.keys():
-            raise ValidationError('Forseti requires resource field', ['resource'])
+        if "resource" not in data.keys():
+            raise ValidationError("Forseti requires resource field", ["resource"])
 
-        if 'resource_type' not in data.keys():
-            raise ValidationError('Forseti requires resource_type field', ['resource_type'])
+        if "resource_type" not in data.keys():
+            raise ValidationError("Forseti requires resource_type field", ["resource_type"])
 
-        resource = data['resource']
+        resource = data["resource"]
 
         for field in SUPPORTED_RESOURCE.get(resource):
-            if field not in data['violation_data']:
-                raise ValidationError(f'{resource} resource requires member field {field} in violation_data',
-                                      ['violation_data'])
+            if field not in data["violation_data"]:
+                raise ValidationError(
+                    f"{resource} resource requires member field {field} in violation_data", ["violation_data"]
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+black==19.3b0
+coverage==4.5.4
+pycodestyle==2.5.0
+pytest==5.2.1
+pytest-cov==2.8.1
+pytest-freezegun==0.3.0.post1
+tox==2.9.1
+pylint==2.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pycodestyle]
-max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -19,29 +19,19 @@ setuptools.setup(
     name="comet-common",
     version="2.1.0",
     url="https://github.com/spotify/comet-common",
-
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",
-
     description="Comet Distributed Security Notification Framework",
     long_description=open('README.md', 'r+', encoding='utf-8').read(),
-
     packages=['comet_common'],
-
-    install_requires=[
-        'comet-core~=2.1',
-        'google-cloud-pubsub~=0.37',
-        'marshmallow~=2.17'
-    ],
-
+    install_requires=['comet-core~=2.1', 'google-cloud-pubsub~=0.37', 'marshmallow~=2.17'],
     include_package_data=True,
-
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
-        'Programming Language :: Python :: 3.7'
-        'Programming Language :: Python :: 3.8'
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setuptools.setup(
     author_email="wasabi@spotify.com",
     description="Comet Distributed Security Notification Framework",
     long_description=open('README.md', 'r+', encoding='utf-8').read(),
-    packages=['comet_common'],
-    install_requires=['comet-core~=2.1', 'google-cloud-pubsub~=0.37', 'marshmallow~=2.17'],
+    packages=["comet_common"],
+    install_requires=["comet-core~=2.1", "google-cloud-pubsub~=0.37", "marshmallow~=2.17"],
     include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setuptools.setup(
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.8'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",
     description="Comet Distributed Security Notification Framework",
-    long_description=open('README.md', 'r+', encoding='utf-8').read(),
+    long_description=open("README.md", "r+", encoding="utf-8").read(),
     packages=["comet_common"],
     install_requires=["comet-core~=2.1", "google-cloud-pubsub~=0.37", "marshmallow~=2.17"],
     include_package_data=True,

--- a/tests/test_input_google_pubsub.py
+++ b/tests/test_input_google_pubsub.py
@@ -28,8 +28,8 @@ def test_input_google_pubsub_passingok():
         message_callback = Mock(return_value=True)
         pubsubinput = PubSubInput(message_callback=message_callback, subscription_name="something")
         message = Mock()
-        message.attributes.get.return_value = 'test_type'
-        message.data.decode.return_value = '{}'
+        message.attributes.get.return_value = "test_type"
+        message.data.decode.return_value = "{}"
 
         pubsubinput.callback(message)
 
@@ -45,13 +45,13 @@ def test_input_google_pubsub_failingtodecode():
         message_callback = Mock(return_value=False)
         pubsubinput = PubSubInput(message_callback=message_callback, subscription_name="something")
         message = Mock()
-        message.attributes.get.return_value = 'test_type'
+        message.attributes.get.return_value = "test_type"
         message.data.decode.side_effect = Exception("Mock Exception")
 
         with pytest.raises(Exception) as excinfo:
             pubsubinput.callback(message)
 
-        assert excinfo.value.args[0] == 'Mock Exception'
+        assert excinfo.value.args[0] == "Mock Exception"
         message.nack.assert_called_once()
 
 
@@ -62,8 +62,8 @@ def test_input_google_pubsub_nocallback():
         message_callback = Mock(return_value=False)
         pubsubinput = PubSubInput(message_callback=message_callback, subscription_name="something")
         message = Mock()
-        message.attributes.get.return_value = 'test_type'
-        message.data.decode.side_effect = '{}'
+        message.attributes.get.return_value = "test_type"
+        message.data.decode.side_effect = "{}"
 
         pubsubinput.callback(message)
 
@@ -86,11 +86,11 @@ def test_input_google_pubsub_invalid_message_drop():
     with patch("comet_common.comet_input_google_pubsub.pubsub.SubscriberClient") as mockpubsub:
         mockpubsub().subscribe.return_value = None
         message_callback = Mock()
-        message_callback.side_effect = CometAlertException('moo', drop=True)
+        message_callback.side_effect = CometAlertException("moo", drop=True)
         pubsubinput = PubSubInput(message_callback=message_callback, subscription_name="something")
         message = Mock()
-        message.attributes.get.return_value = 'test_type'
-        message.data.decode.return_value = {'subtype': ''}
+        message.attributes.get.return_value = "test_type"
+        message.data.decode.return_value = {"subtype": ""}
 
         pubsubinput.callback(message)
 
@@ -101,11 +101,11 @@ def test_input_google_pubsub_invalid_message_keep():
     with patch("comet_common.comet_input_google_pubsub.pubsub.SubscriberClient") as mockpubsub:
         mockpubsub().subscribe.return_value = None
         message_callback = Mock()
-        message_callback.side_effect = CometAlertException('mooh')
+        message_callback.side_effect = CometAlertException("mooh")
         pubsubinput = PubSubInput(message_callback=message_callback, subscription_name="something")
         message = Mock()
-        message.attributes.get.return_value = 'test_type'
-        message.data.decode.return_value = {'subtype': ''}
+        message.attributes.get.return_value = "test_type"
+        message.data.decode.return_value = {"subtype": ""}
 
         pubsubinput.callback(message)
 

--- a/tests/test_parser_detectify.py
+++ b/tests/test_parser_detectify.py
@@ -16,17 +16,11 @@
 
 from comet_common.comet_parser_detectify import DetectifyDefinitionSchema, DetectifyPayloadSchema, DetectifySchema
 
-payload_DetectifyDefinitionSchema = dict(description='')
-payload_DetectifyPayloadSchema = dict(signature='',
-                                      url='',
-                                      title='',
-                                      found_at='',
-                                      report_token='',
-                                      definition=payload_DetectifyDefinitionSchema)
-payload_DetectifySchema = dict(scan_token='',
-                               profile_token='',
-                               domain='',
-                               payload=payload_DetectifyPayloadSchema)
+payload_DetectifyDefinitionSchema = dict(description="")
+payload_DetectifyPayloadSchema = dict(
+    signature="", url="", title="", found_at="", report_token="", definition=payload_DetectifyDefinitionSchema
+)
+payload_DetectifySchema = dict(scan_token="", profile_token="", domain="", payload=payload_DetectifyPayloadSchema)
 
 
 def test_DetectifyDefinitionSchema():

--- a/tests/test_parser_forseti.py
+++ b/tests/test_parser_forseti.py
@@ -18,22 +18,24 @@
 from comet_common.comet_parser_forseti import ForsetiSchema, SUPPORTED_RESOURCE_TYPES, SUPPORTED_RESOURCE
 
 
-_payload_ForsetiSchema = dict(id=0,
-                              project_id='',
-                              project_owner='',
-                              resource=None,
-                              resource_id='',
-                              resource_type=None,
-                              violation_data=dict(resource='', violation_data=dict()))
+_payload_ForsetiSchema = dict(
+    id=0,
+    project_id="",
+    project_owner="",
+    resource=None,
+    resource_id="",
+    resource_type=None,
+    violation_data=dict(resource="", violation_data=dict()),
+)
 
 
 def test_ForsetiSchema_parsedok():
     payload_ForsetiSchema = dict(_payload_ForsetiSchema)
     for srt in SUPPORTED_RESOURCE_TYPES:
         for sr in SUPPORTED_RESOURCE:
-            payload_ForsetiSchema['resource'] = sr
-            payload_ForsetiSchema['resource_type'] = srt
-            payload_ForsetiSchema['violation_data'] = dict([(k, '') for k in SUPPORTED_RESOURCE[sr]])
+            payload_ForsetiSchema["resource"] = sr
+            payload_ForsetiSchema["resource_type"] = srt
+            payload_ForsetiSchema["violation_data"] = dict([(k, "") for k in SUPPORTED_RESOURCE[sr]])
             assert ForsetiSchema().validate(payload_ForsetiSchema) == {}
 
 
@@ -41,14 +43,14 @@ def test_ForsetiSchema_fail():
     payload_ForsetiSchema = dict(_payload_ForsetiSchema)
     err = ForsetiSchema().validate(payload_ForsetiSchema)
     print(err)
-    assert 'Forseti requires resource field' in err.get('resource', [])
-    assert 'resource' in err
-    assert 'resource_type' in err
+    assert "Forseti requires resource field" in err.get("resource", [])
+    assert "resource" in err
+    assert "resource_type" in err
 
-    payload_ForsetiSchema['resource'] = list(SUPPORTED_RESOURCE.keys())[0]
+    payload_ForsetiSchema["resource"] = list(SUPPORTED_RESOURCE.keys())[0]
     err = ForsetiSchema().validate(payload_ForsetiSchema)
-    assert 'Forseti requires resource_type field' in err.get('resource_type', [])
+    assert "Forseti requires resource_type field" in err.get("resource_type", [])
 
-    payload_ForsetiSchema['resource_type'] = SUPPORTED_RESOURCE_TYPES[0]
+    payload_ForsetiSchema["resource_type"] = SUPPORTED_RESOURCE_TYPES[0]
     err = ForsetiSchema().validate(payload_ForsetiSchema)
-    assert 'violation_data' in err
+    assert "violation_data" in err

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,25 @@
 [tox]
 envlist=
+    black,
+    lint,
     py36,
-    lint
+    py37,
+    py38,
 
 [testenv]
+deps = -rrequirements-dev.txt
 commands =
     coverage erase
-    coverage run --source {toxinidir}/comet_common/ -m py.test --junitxml=test-reports/junit.xml {toxinidir}/tests/
-    coverage report -m
-    coverage xml -o test-reports/cobertura.xml
-deps =
-    coverage
-    pycodestyle
-    pylint
-    pytest
+    pytest --junitxml=test-reports/junit.xml --cov={toxinidir}/comet --cov={toxinidir}/comet_core/ --cov-report=term --cov-report=xml:test-reports/cobertura.xml {toxinidir}/comet_common/
+
+[testenv:black]
+basepython=python3.6
+deps = black
+skip_install = true
+commands =
+    black . --diff --check -l 120
 
 [testenv:lint]
 basepython=python3.6
 commands =
-    pylint --rcfile={toxinidir}/.pylintrc comet_common
-    pycodestyle {toxinidir}/comet_common
+    pylint --rcfile={toxinidir}/.pylintrc comet_core

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist=
 deps = -rrequirements-dev.txt
 commands =
     coverage erase
-    pytest --junitxml=test-reports/junit.xml --cov={toxinidir}/comet --cov={toxinidir}/comet_core/ --cov-report=term --cov-report=xml:test-reports/cobertura.xml {toxinidir}/comet_common/
+    pytest --junitxml=test-reports/junit.xml --cov={toxinidir}/comet_common --cov-report=term --cov-report=xml:test-reports/cobertura.xml {toxinidir}/tests/
 
 [testenv:black]
 basepython=python3.6


### PR DESCRIPTION
Update the dev environment to be consistent with other comet projects.
Adds Black linting in tox and ran black on the whole codebase.

Updates the supported Python trove classifiers and ensures that tox runs the tests against all supported versions.

See also: https://github.com/spotify/comet-core/pull/27