### PR TITLE
Add severity score to DetectifySchema

### DIFF
--- a/comet_common/comet_parser_detectify.py
+++ b/comet_common/comet_parser_detectify.py
@@ -46,4 +46,5 @@ class DetectifySchema(Schema):
     scan_token = fields.Str(required=True)
     profile_token = fields.Str(required=True)
     domain = fields.Str(required=True)
+    score = fields.Float(required=False)
     payload = fields.Nested(DetectifyPayloadSchema, required=True)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="comet-common",
-    version="2.1.5",
+    version="2.2.0",
     url="https://github.com/spotify/comet-common",
     author="Spotify Platform Security",
     author_email="wasabi@spotify.com",

--- a/tests/test_parser_detectify.py
+++ b/tests/test_parser_detectify.py
@@ -21,6 +21,7 @@ payload_DetectifyPayloadSchema = dict(
     signature="", url="", title="", found_at="", report_token="", definition=payload_DetectifyDefinitionSchema
 )
 payload_DetectifySchema = dict(scan_token="", profile_token="", domain="", payload=payload_DetectifyPayloadSchema)
+payload_DetectifySchema_complete = {**payload_DetectifySchema, "score": 7.1}
 
 
 def test_DetectifyDefinitionSchema():
@@ -39,3 +40,5 @@ def test_DetectifySchema():
     assert DetectifySchema().validate(payload_DetectifySchema) == {}
     for k in payload_DetectifySchema:
         assert k in DetectifySchema().validate({})
+    assert DetectifySchema().validate(payload_DetectifySchema_complete) == {}
+    assert "score" not in DetectifySchema().validate({})


### PR DESCRIPTION
Add severity score to DetectifySchema

## Description
We want severity score to be stored/notified for our team's need but it feels like a common necessity to store and notify severity score so I'm making a PR here.

Making it optional for backward compatibility but i can change that if it's unnecessary.
And I used the word "score" because that's the one showing up in Detectify response.

## Checklist

<!-- Go over all the following points, and put an `x` in the boxes that applies. -->

- [x] Changes are covered by tests.
- [ ] Documentation has been updated with the new changes.
- [x] Readme is still relevant after the changes has been introduced.
